### PR TITLE
🐛 Fix types issues in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
   "name": "@reedsy/express-ws",
-  "version": "5.0.0-reedsy-3.0.1",
+  "version": "5.0.0-reedsy-3.0.2",
   "description": "WebSocket endpoints for Express applications",
   "exports": {
-    "require": "./index.cjs",
-    "import": "./index.mjs"
+    "require": {
+      "types": "./index.d.ts",
+      "default": "./index.cjs"
+    },
+    "import": {
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
+    }
   },
   "module": "src/index",
-  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint src/"
   },


### PR DESCRIPTION
At the moment when why try to run test in editor we get this error:
```
There are types at '@reedsy/express-ws/index.d.ts', but this result could not be resolved when respecting package.json "exports".
```

This was not a problem before as other apps does not use `@reedsy/express-ws` directly.