### PR TITLE
🏷️ Fix type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare namespace expressWs {
         getWss(): ws.Server;
     }
 
-    type WebsocketRequestHandler = (ws: ws, req: express.Request, next: express.NextFunction) => void;
+    type WebsocketRequestHandler = (ws: ws.WebSocket, req: express.Request, next: express.NextFunction) => void;
     type WebsocketMethod<T> = (route: core.PathParams, ...middlewares: WebsocketRequestHandler[]) => T;
 
     interface WithWebsocketMethod {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/express-ws",
-  "version": "5.0.0-reedsy-4.0.0",
+  "version": "5.0.0-reedsy-4.0.1",
   "description": "WebSocket endpoints for Express applications",
   "type": "module",
   "module": "./index.js",


### PR DESCRIPTION
Downstream builds fail with:

```
Error: ../../node_modules/@reedsy/express-ws/index.d.ts(40,41): error TS2709: Cannot use namespace 'ws' as a type.
```

This change uses `ws.WebSocket` instead.