### PR TITLE
🔧 Set `main` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@reedsy/express-ws",
-  "version": "5.0.0-reedsy-4.0.1",
+  "version": "5.0.0-reedsy-4.0.2",
   "description": "WebSocket endpoints for Express applications",
   "type": "module",
-  "module": "./index.js",
+  "main": "./index.js",
   "types": "./index.d.ts",
   "scripts": {
     "lint": "eslint src/"


### PR DESCRIPTION
Fixes downstream errors:

```
(node:97037) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json
```