### PR TITLE
Support Express 5 stable and fix async handler errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/express-ws",
-  "version": "5.0.0-reedsy-5.0.0",
+  "version": "5.0.0-reedsy-5.1.0",
   "description": "WebSocket endpoints for Express applications",
   "type": "module",
   "main": "./index.js",
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "express": "^4.0.0 || ^5.0.0-alpha.1"
+    "express": "^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=4.5.0"
@@ -46,6 +46,6 @@
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.29.1",
-    "express": "^5.0.0-alpha.6"
+    "express": "^5.0.0"
   }
 }

--- a/src/wrap-middleware.js
+++ b/src/wrap-middleware.js
@@ -1,10 +1,10 @@
 export function wrapMiddleware(middleware) {
-  return (req, res, next) => {
+  return async (req, res, next) => {
     if (req.ws !== null && req.ws !== undefined) {
       req.wsHandled = true;
       try {
         /* Unpack the `.ws` property and call the actual handler. */
-        middleware(req.ws, req, next);
+        await middleware(req.ws, req, next);
       } catch (err) {
         /* If an error is thrown, let's send that on to any error handling */
         next(err);


### PR DESCRIPTION
## Summary

- Bumps `peerDependencies` and `devDependencies` from the alpha Express 5 range (`^5.0.0-alpha.1` / `^5.0.0-alpha.6`) to the stable `^5.0.0`.
- Makes `wrapMiddleware` `async` and `await`s the user-supplied handler, so rejected promises from async WebSocket handlers are caught by the `try/catch` and forwarded to `next(err)` instead of becoming silent unhandled rejections. This also lets Express 5's own promise-handling layer catch any uncaught rejections from the wrapper itself.
- Backwards-compatible with Express 4: errors are still forwarded via `next(err)`, not relying on Express 5 promise handling.

## Test plan

- [ ] `npm install` — no peer dependency conflicts with `express@5`.
- [ ] Run an example (`node examples/simple.js`) against Express 5 and confirm WebSocket connections work.
- [ ] Test with an async WebSocket handler that throws — confirm the error reaches Express error middleware rather than becoming an unhandled rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)