### PR TITLE
🐛 Patch `Router.prototype` so `router.ws()` works on Express 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/express-ws",
-  "version": "5.0.0-reedsy-5.1.0",
+  "version": "5.0.0-reedsy-5.1.1",
   "description": "WebSocket endpoints for Express applications",
   "type": "module",
   "main": "./index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,22 @@ export function expressWs(app, httpServer, options = {}) {
    * when using the standard Express Router, to use the `.ws` method without any further calls
    * to `makeRouter`. When using a custom router, the use of `makeRouter` may still be necessary.
    *
-   * This approach works, because Express does a strange mixin hack - the Router factory
-   * function is simultaneously the prototype that gets assigned to the resulting Router
-   * object. */
+   * Express 4 and Express 5 lay this out differently:
+   *   - In Express 4, the `Router` factory function doubles as the prototype object - new
+   *     routers are linked to it via `setPrototypeOf(router, Router)` and the routing methods
+   *     are assigned directly onto `Router`. Patching `Router` itself is therefore enough.
+   *   - In Express 5, the routing methods live on `Router.prototype` (a function-as-prototype
+   *     object), and instances inherit from a `new Router()` whose own prototype is
+   *     `Router.prototype`. Patching `Router` itself no longer reaches instances; we have to
+   *     patch `Router.prototype` instead.
+   *
+   * Detect Express 5 by the presence of routing methods on the prototype, and patch whichever
+   * target actually sits on the lookup chain that `router.ws(...)` resolves through. */
   if (!options.leaveRouterUntouched) {
-    addWsMethod(express.Router);
+    const routerPrototype = (express.Router.prototype && typeof express.Router.prototype.get === 'function')
+      ? express.Router.prototype
+      : express.Router;
+    addWsMethod(routerPrototype);
   }
 
   // allow caller to pass in options to WebSocketServer constructor


### PR DESCRIPTION
At the moment, the package declares `express ^4.0.0 || ^5.0.0` as a peer dependency, but calling `router.ws('/foo', ...)` on an Express 5 router throws `TypeError: router.ws is not a function`.

This happens because Express 4 and Express 5 lay out their `Router` very differently. In Express 4, the `Router` factory function doubles as the prototype object that instances inherit from - `setPrototypeOf(router, Router)` links them, and the routing methods are assigned directly onto `Router`. Patching `Router` itself is enough to reach every instance.

In Express 5, the factory function is no longer in the lookup chain. Instances inherit from a `new Router()` whose own prototype is `Router.prototype` (a function-as-prototype object), and the routing methods (`get`, `use`, `post`, ...) live on `Router.prototype`. So `addWsMethod(express.Router)` puts `.ws` on the factory function, where no instance can ever find it.

This change detects Express 5 by the presence of routing methods on `Router.prototype` and patches whichever target actually sits on the lookup chain. Express 4 keeps its existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

